### PR TITLE
Test1

### DIFF
--- a/experiment_log.md
+++ b/experiment_log.md
@@ -1,3 +1,5 @@
-1. Was using MSE , but I think BCE would be a better choice
-2. Gonna split my data in validation set and training set and train the model based on that instead of when loss decreases
-3. I can see the model was stopping learning after 10-15 epochs so adding a scheduler in learning rate so that my learning rate changes when the model starts stagnating
+1. removed sigmoid from scout output letting it to be unbounded and then apply sigmoid at the loss boundary, Sigmoid should be applied once, at the loss function, not inside the model.
+2. adding weighted bce loss
+3. reduced model size, because i dont have that much data
+4. trying to increase dropout because the model is overfitting
+5. adding weight decay in adam

--- a/inference.py
+++ b/inference.py
@@ -75,7 +75,8 @@ def run_inference(model, sentence_embeddings):
         score_matrix: [N, N]
     """
     output = model(sentence_embeddings)  # [1, N, N]
-    return output.squeeze(0)              # [N, N]
+    scores = torch.sigmoid(output/0.5)  # ← add this
+    return scores.squeeze(0)              # [N, N]
 
 
 # -----------------------------
@@ -85,9 +86,12 @@ if __name__ == "__main__":
 
     # Example sentences
     sentences = [
-        "the tap is leaking",
-        "call a plumber"
-    ]
+    "the tap is leaking",
+    "call a plumber",
+    "water is dripping from the faucet handle",
+    "tighten the valve nut under the sink",
+    "plumbers charge by the hour",
+]
 
 
 

--- a/inference.py
+++ b/inference.py
@@ -75,7 +75,7 @@ def run_inference(model, sentence_embeddings):
         score_matrix: [N, N]
     """
     output = model(sentence_embeddings)  # [1, N, N]
-    scores = torch.sigmoid(output/0.5)  # ← add this
+    scores = torch.sigmoid(output/0.5) 
     return scores.squeeze(0)              # [N, N]
 
 

--- a/main.py
+++ b/main.py
@@ -80,7 +80,11 @@ class SigmoidAttentionLayer(nn.Module):
 
         # used Sigmoid instead of Softmax, because I didnt wanted sum = 1 for a row , Now every cell is 0.0 to 1.0 independently.
         attn_probs = torch.sigmoid(raw_scores)
-        attn_output = (attn_probs @ v) / (n ** 0.5) # Soft scaling factor
+        # Unlike softmax, sigmoid rows don't sum to 1 — they can sum up to N.
+        # This means attn_probs @ v is a weighted sum, not a weighted average,
+        # and its magnitude grows with sequence length. Dividing by sqrt(N)
+        # keeps the output scale stable regardless of how many sentences are in the input.
+        attn_output = (attn_probs @ v) / (n ** 0.5)
                 
         attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, n, self.d_model)
         x = x + self.dropout(self.out_proj(attn_output))


### PR DESCRIPTION
Earlier my model was not able to produce relevant scores for the given elements i made changes in the training and inference script based on some hypothesis i had, changes made - 

1. added weighted bce loss - 
    MY target matrix was extremely sparse most values were 0.0, very few were 0.7-0.9. Without weighting, the model was discovering a shortcut: predict near-zero everywhere and get a low loss, because 80% of targets were zero anyway. It never learned to identify the high-relevance pairs because they're a tiny minority. pos_weight=20 means every high-relevance pair counts 20x more in the loss calculation, forcing the model to actually care about getting those right. BCE is also more natural than MSE here because your targets are conceptually probabilities between 0 and 1 BCE is designed for that, MSE isn't.

3. reduced model size, because i dont have that much data
4. increased dropout because the model was overfitting
5. added weight decay in adam - Without weight decay, model weights can grow very large during training. Large weights mean the model is making very confident, very specific decisions which van be the cause of overfitting.
